### PR TITLE
Updated calculations in grid.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Integrate or build upon it for free in your personal or commercial projects. Don
 
 ## Fork
 
+Forked from Daniel-KM's repo to contribute debugging.
+
 Upgraded to native javascript without dependencies and improved by [Daniel-KM](https://gitlab.com/Daniel-KM)
 
 This gallery is available in [Omeka S](https://omeka.org/s) through the module [Block Plus](https://gitlab.com/Daniel-KM/Omeka-S-module-BlockPlus).

--- a/js/grid.js
+++ b/js/grid.js
@@ -338,11 +338,11 @@ document.addEventListener("DOMContentLoaded", function() {
             },
             calcHeight: function() {
                 var heightPreview = winsize.height - this.item.dataset.height - marginExpanded - (this.item.dataset.height * marginItemHeightPercent / 100),
-                itemHeight = winsize.height - (this.item.dataset.height * marginItemHeightPercent / 100);
+                itemHeight = parseFloat(winsize.height) - parseFloat(this.item.dataset.height * marginItemHeightPercent / 100);
 
                 if (heightPreview < settings.minHeight) {
                     heightPreview = settings.minHeight;
-                    itemHeight = settings.minHeight + this.item.dataset.height + marginExpanded;
+                    itemHeight = parseFloat(settings.minHeight) + parseFloat(this.item.dataset.height) + parseFloat(marginExpanded);
                 }
 
                 this.height = heightPreview;
@@ -373,7 +373,7 @@ document.addEventListener("DOMContentLoaded", function() {
                 // case 3: preview height + item height does not fit in window´s height and preview height is bigger than window´s height
                 var position = this.item.dataset.offsetTop,
                     previewOffsetT = this.previewEl.getBoundingClientRect().top - scrollExtra,
-                    scrollVal = this.height + this.item.dataset.height + marginExpanded <= winsize.height
+                    scrollVal = parseFloat(this.height) + parseFloat(this.item.dataset.height) + parseFloat(marginExpanded) <= parseFloat(winsize.height)
                         ? position
                         : this.height < winsize.height
                             ? previewOffsetT - (winsize.height - this.height)


### PR DESCRIPTION
There is some strange scrolling going on. The values for window height are concatenated in stead of addition. This code fixes that.